### PR TITLE
Travis: install github.com/jpillora/backoff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ go:
 - "1.12"
 
 install:
-- go get github.com/stretchr/testify
+- go get github.com/jpillora/backoff
 - go get github.com/prometheus/client_golang/prometheus
+- go get github.com/stretchr/testify
 - go get golang.org/x/net/context
 - go get golang.org/x/net/trace
 


### PR DESCRIPTION
This dependency was previously missing, causing builds to fail (see https://travis-ci.org/mwitkow/go-conntrack/jobs/559296369#L469 for example).

CI failure possibly introduced by https://github.com/mwitkow/go-conntrack/pull/7 (ping @devnev)