### PR TITLE
Expose the number of open connections.

### DIFF
--- a/dialer_reporter.go
+++ b/dialer_reporter.go
@@ -53,6 +53,14 @@ var (
 			Name:      "dialer_conn_closed_total",
 			Help:      "Total number of connections closed which originated from the dialer of a given name.",
 		}, []string{"dialer_name"})
+
+	dialerConnOpen = prom.NewGaugeVec(
+		prom.GaugeOpts{
+			Namespace: "net",
+			Subsystem: "conntrack",
+			Name:      "dialer_conn_open",
+			Help:      "Number of open connections which originated from the dialer of a given name.",
+		}, []string{"dialer_name"})
 )
 
 func init() {
@@ -60,6 +68,7 @@ func init() {
 	prom.MustRegister(dialerConnEstablishedTotal)
 	prom.MustRegister(dialerConnFailedTotal)
 	prom.MustRegister(dialerConnClosedTotal)
+	prom.MustRegister(dialerConnOpen)
 }
 
 // preRegisterDialerMetrics pre-populates Prometheus labels for the given dialer name, to avoid Prometheus missing labels issue.
@@ -70,6 +79,7 @@ func PreRegisterDialerMetrics(dialerName string) {
 		dialerConnFailedTotal.WithLabelValues(dialerName, string(reason))
 	}
 	dialerConnClosedTotal.WithLabelValues(dialerName)
+	dialerConnOpen.WithLabelValues(dialerName)
 }
 
 func reportDialerConnAttempt(dialerName string) {
@@ -78,10 +88,12 @@ func reportDialerConnAttempt(dialerName string) {
 
 func reportDialerConnEstablished(dialerName string) {
 	dialerConnEstablishedTotal.WithLabelValues(dialerName).Inc()
+	dialerConnOpen.WithLabelValues(dialerName).Inc()
 }
 
 func reportDialerConnClosed(dialerName string) {
 	dialerConnClosedTotal.WithLabelValues(dialerName).Inc()
+	dialerConnOpen.WithLabelValues(dialerName).Dec()
 }
 
 func reportDialerConnFailed(dialerName string, err error) {

--- a/listener_reporter.go
+++ b/listener_reporter.go
@@ -21,23 +21,34 @@ var (
 			Name:      "listener_conn_closed_total",
 			Help:      "Total number of connections closed that were made to the listener of a given name.",
 		}, []string{"listener_name"})
+	listenerOpen = prom.NewGaugeVec(
+		prom.GaugeOpts{
+			Namespace: "net",
+			Subsystem: "conntrack",
+			Name:      "listener_conn_open",
+			Help:      "Number of open connections to the listener of a given name.",
+		}, []string{"listener_name"})
 )
 
 func init() {
 	prom.MustRegister(listenerAcceptedTotal)
 	prom.MustRegister(listenerClosedTotal)
+	prom.MustRegister(listenerOpen)
 }
 
 // preRegisterListener pre-populates Prometheus labels for the given listener name, to avoid Prometheus missing labels issue.
 func preRegisterListenerMetrics(listenerName string) {
 	listenerAcceptedTotal.WithLabelValues(listenerName)
 	listenerClosedTotal.WithLabelValues(listenerName)
+	listenerOpen.WithLabelValues(listenerName)
 }
 
 func reportListenerConnAccepted(listenerName string) {
 	listenerAcceptedTotal.WithLabelValues(listenerName).Inc()
+	listenerOpen.WithLabelValues(listenerName).Inc()
 }
 
 func reportListenerConnClosed(listenerName string) {
 	listenerClosedTotal.WithLabelValues(listenerName).Inc()
+	listenerOpen.WithLabelValues(listenerName).Dec()
 }


### PR DESCRIPTION
Currently you'd have to subtract counters,
which is not advised as it's racy.